### PR TITLE
Fixed the opposite axis bug

### DIFF
--- a/lib/flipcard/flip_card.dart
+++ b/lib/flipcard/flip_card.dart
@@ -96,7 +96,7 @@ class FlipCardState extends State<FlipCard> with TickerProviderStateMixin {
         late Matrix4 transform;
         late Matrix4 transformForBack;
         if (isFront) angle += anglePlus;
-        if (widget.axis == FlipAxis.horizontal) {
+        if (widget.axis == FlipAxis.vertical) {
           transform = Matrix4.identity()
             ..setEntry(3, 2, 0.001)
             ..rotateX(angle);


### PR DESCRIPTION
The problem was that if you will provide `axis` as `FlipAxis.vertical` then it was flipping in `horizontal` direction and vice versa.

✅ Fixed the issue by updating the `FlipAxis` in if condition of `FlipCard` from `FlipAxis.horizontal` to `FlipAxis.vertical`

![Screenshot 2024-08-18 at 1 33 53 PM](https://github.com/user-attachments/assets/1c22f45d-c3ce-4f8f-9ed5-fb1544c6e8ed)
